### PR TITLE
feat: Reorganize sidebar points layout and add average daily points

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -331,6 +331,13 @@ function App() {
     return total;
   };
 
+  const calculateAverageDailyPoints = (): number => {
+    const dailyPoints = Object.values(appData.dailyData).map(dayData => calculatePointsForDay(dayData));
+    if (dailyPoints.length === 0) return 0;
+    const total = dailyPoints.reduce((sum, points) => sum + points, 0);
+    return Math.round(total / dailyPoints.length);
+  };
+
   const calculateTodaysPoints = (): number => {
     const dayData = getTodaysData();
     let points = 0;
@@ -700,6 +707,7 @@ function App() {
         onToggleDarkMode={() => setIsDarkMode(!isDarkMode)}
         todaysPoints={calculateTodaysPoints()}
         highScore={calculatePreviousHighScore()}
+        averagePoints={calculateAverageDailyPoints()}
         pointsDeltaFromHigh={calculateTodaysPoints() - calculatePreviousHighScore()}
         onSignOut={handleSignOut}
         isMobileOpen={mobileSidebarOpen}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -304,7 +304,7 @@ const Dashboard: React.FC<DashboardProps> = ({
   }
 
   return (
-    <div className="w-full max-w-4xl mx-auto animate-fade-in">
+    <div className="w-full max-w-4xl mx-auto space-y-6 animate-fade-in">
       
       {/* Welcome Section */}
       <div className={`backdrop-blur-sm rounded-2xl p-6 shadow-lg border animate-slide-up ${
@@ -367,8 +367,7 @@ const Dashboard: React.FC<DashboardProps> = ({
         </div>
       </div>
 
-      <div>
-        {/* Good Day Vision */}
+      {/* Good Day Vision */}
         {todaysData.goodDayVision && (
           <div className={`backdrop-blur-sm rounded-2xl p-6 shadow-lg border animate-slide-up ${
             isDarkMode 
@@ -1135,7 +1134,6 @@ const Dashboard: React.FC<DashboardProps> = ({
             </div>
           </div>
         )}
-      </div>
     </div>
   );
 };

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -40,6 +40,7 @@ interface SidebarProps {
   onToggleDarkMode: () => void;
   todaysPoints: number;
   highScore: number;
+  averagePoints: number;
   pointsDeltaFromHigh: number;
   onSignOut: () => void;
   isMobileOpen: boolean;
@@ -79,6 +80,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onToggleDarkMode,
   todaysPoints,
   highScore,
+  averagePoints,
   pointsDeltaFromHigh,
   onSignOut,
   isMobileOpen,
@@ -244,55 +246,60 @@ const Sidebar: React.FC<SidebarProps> = ({
 
         {/* Stats Section */}
         {!isCollapsed && (
-          <div className="grid grid-cols-2 gap-3 animate-slide-up">
-            {/* Current Streak */}
-            <div className={`rounded-lg p-3 border ${
-              isDarkMode 
-                ? 'bg-gradient-to-r from-rose-900/50 to-rose-800/50 border-rose-700' 
-                : 'bg-gradient-to-r from-rose-50 to-rose-100 border-rose-200'
-            }`}>
-              <div className="flex items-center space-x-2 text-rose-600">
-                <Flame size={16} />
-                <span className="font-bold text-sm">{currentStreak}</span>
+          <div className="space-y-3 animate-slide-up">
+            {/* Streaks Row - Top */}
+            <div className="grid grid-cols-2 gap-3">
+              {/* Current Streak */}
+              <div className={`rounded-lg p-3 border ${
+                isDarkMode 
+                  ? 'bg-gradient-to-r from-rose-900/50 to-rose-800/50 border-rose-700' 
+                  : 'bg-gradient-to-r from-rose-50 to-rose-100 border-rose-200'
+              }`}>
+                <div className="flex items-center space-x-2 text-rose-600">
+                  <Flame size={16} />
+                  <span className="font-bold text-sm">{currentStreak}</span>
+                </div>
+                <p className={`text-xs mt-1 ${
+                  isDarkMode ? 'text-rose-300' : 'text-rose-700'
+                }`}>Streak</p>
               </div>
-              <p className={`text-xs mt-1 ${
-                isDarkMode ? 'text-rose-300' : 'text-rose-700'
-              }`}>Streak</p>
-            </div>
-            {/* Longest Streak */}
-            <div className={`rounded-lg p-3 border ${
-              isDarkMode 
-                ? 'bg-gradient-to-r from-pink-900/50 to-pink-800/50 border-pink-700' 
-                : 'bg-gradient-to-r from-pink-50 to-pink-100 border-pink-200'
-            }`}>
-              <div className="flex items-center space-x-2 text-pink-600">
-                <Flame size={16} />
-                <span className="font-bold text-sm">{longestStreak}</span>
+              {/* Longest Streak */}
+              <div className={`rounded-lg p-3 border ${
+                isDarkMode 
+                  ? 'bg-gradient-to-r from-pink-900/50 to-pink-800/50 border-pink-700' 
+                  : 'bg-gradient-to-r from-pink-50 to-pink-100 border-pink-200'
+              }`}>
+                <div className="flex items-center space-x-2 text-pink-600">
+                  <Flame size={16} />
+                  <span className="font-bold text-sm">{longestStreak}</span>
+                </div>
+                <p className={`text-xs mt-1 ${
+                  isDarkMode ? 'text-pink-300' : 'text-pink-700'
+                }`}>Best</p>
               </div>
-              <p className={`text-xs mt-1 ${
-                isDarkMode ? 'text-pink-300' : 'text-pink-700'
-              }`}>All-time</p>
             </div>
-            {/* Today's Points */}
+
+            {/* Today's Points - Full Width */}
             <button
               onClick={onOpenPointsBreakdown}
-              className={`rounded-lg p-3 border transition-all duration-200 hover:scale-105 cursor-pointer ${
+              className={`w-full rounded-lg p-3 border transition-all duration-200 hover:scale-105 cursor-pointer ${
                 isDarkMode 
                   ? 'bg-gradient-to-r from-blue-900/50 to-blue-800/50 border-blue-700 hover:from-blue-800/60 hover:to-blue-700/60' 
                   : 'bg-gradient-to-r from-blue-50 to-blue-100 border-blue-200 hover:from-blue-100/80 hover:to-blue-200/80'
               }`}
             >
-              <div className="flex items-center text-blue-600">
+              <div className="flex items-center justify-between text-blue-600">
                 <div className="flex items-center space-x-2">
                   <Trophy size={16} />
-                  <span className="font-bold text-sm">{todaysPoints}</span>
+                  <span className="font-bold text-sm">Today's Points</span>
                 </div>
+                <span className="font-bold text-lg">{todaysPoints}</span>
               </div>
-              <div className={`flex items-center text-xs mt-1 ${
+              <div className={`flex items-center justify-between text-xs mt-1 ${
                 isDarkMode ? 'text-blue-300' : 'text-blue-700'
               }`}>
-                <span>Points</span>
-                <span className={`ml-2 px-1 py-0 rounded-full text-[9px] leading-none font-medium ${
+                <span>Current</span>
+                <span className={`px-1 py-0 rounded-full text-[9px] leading-none font-medium ${
                   pointsDeltaFromHigh === 0
                     ? isDarkMode ? 'bg-gray-800 text-gray-300 border border-gray-700' : 'bg-gray-100 text-gray-600 border border-gray-200'
                     : pointsDeltaFromHigh > 0
@@ -303,22 +310,37 @@ const Sidebar: React.FC<SidebarProps> = ({
                 </span>
               </div>
             </button>
-            {/* High Score */}
-            <div className={`rounded-lg p-3 border ${
-              isDarkMode 
-                ? 'bg-gradient-to-r from-indigo-900/50 to-indigo-800/50 border-indigo-700' 
-                : 'bg-gradient-to-r from-indigo-50 to-indigo-100 border-indigo-200'
-            }`}>
-              <div className="flex items-center text-indigo-600">
-                <div className="flex items-center space-x-2">
+
+            {/* Bottom Row - All-time and Average side by side */}
+            <div className="grid grid-cols-2 gap-3">
+              {/* All-time High Score */}
+              <div className={`rounded-lg p-3 border ${
+                isDarkMode 
+                  ? 'bg-gradient-to-r from-indigo-900/50 to-indigo-800/50 border-indigo-700' 
+                  : 'bg-gradient-to-r from-indigo-50 to-indigo-100 border-indigo-200'
+              }`}>
+                <div className="flex items-center space-x-2 text-indigo-600">
                   <Goal size={16} />
                   <span className="font-bold text-sm">{highScore}</span>
                 </div>
+                <p className={`text-xs mt-1 ${
+                  isDarkMode ? 'text-indigo-300' : 'text-indigo-700'
+                }`}>All-time</p>
               </div>
-              <div className={`flex items-center text-xs mt-1 ${
-                isDarkMode ? 'text-indigo-300' : 'text-indigo-700'
+              
+              {/* Average Daily Points */}
+              <div className={`rounded-lg p-3 border ${
+                isDarkMode 
+                  ? 'bg-gradient-to-r from-emerald-900/50 to-emerald-800/50 border-emerald-700' 
+                  : 'bg-gradient-to-r from-emerald-50 to-emerald-100 border-emerald-200'
               }`}>
-                <span>All-time</span>
+                <div className="flex items-center space-x-2 text-emerald-600">
+                  <BarChart3 size={16} />
+                  <span className="font-bold text-sm">{averagePoints}</span>
+                </div>
+                <p className={`text-xs mt-1 ${
+                  isDarkMode ? 'text-emerald-300' : 'text-emerald-700'
+                }`}>Average</p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
- Add calculateAverageDailyPoints() function to compute historical average
- Reorganize sidebar stats layout:
  - Streaks (Current & Best) at top
  - Today's Points prominently displayed in middle
  - All-time High Score and Average Daily Points side by side at bottom
- Update Sidebar component props to include averagePoints
- Improve visual hierarchy and user experience for points tracking